### PR TITLE
chain preprocess on cpu and training tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 * add `stop` admin command - requires `stop:config`
 * finer-grain route permission checks
+* split training tasks into prepr and train for more efficient GPU resource handling.
 
 ### Fixes and improvements
 * Fix translation tasks not launch for iterations 2+

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ redis
 flask_ini
 shutil
 hashlib
+semver


### PR DESCRIPTION
to go with https://github.com/OpenNMT/nmt-wizard-docker/pull/23 - implement splitting of train tasks into chained preprocess (on CPU only) and actual training.
* condition the split based on docker version: has to be >=1.4.0 (should be adapted to actual version)
* preprocess tasks are launched on CPU only
* change output to show details of prepr/train/translate tasks