### PR TITLE
fix

### DIFF
--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -555,6 +555,7 @@ def launch(service):
             task_ids.append("%s\t%s\tngpus: %d, ncpus: %d" % ("prepr", prepr_task_id, 0, content["ncpus"]))
             remove_config_option(train_command)
             change_parent_task(train_command, prepr_task_id)
+            parent_task_id = prepr_task_id
             content["docker"]["command"] = train_command
 
         if task_type != "prepr":

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -555,7 +555,8 @@ def launch(service):
             task_ids.append("%s\t%s\tngpus: %d, ncpus: %d" % ("prepr", prepr_task_id, 0, content["ncpus"]))
             remove_config_option(train_command)
             change_parent_task(train_command, prepr_task_id)
-            parent_task_id = prepr_task_id
+            if parent_task_id is None:
+                parent_task_id = prepr_task_id
             content["docker"]["command"] = train_command
 
         if task_type != "prepr":


### PR DESCRIPTION
Fix a mis-deletion caused by c389ae9366ffa7e1f056d267c8610e8aeec1c793.
This will cause different task name for "preprocess" and "train".
