### PR TITLE
refs #53416: fix error when encoding special char with system default…

### DIFF
--- a/server/nmtwizard/task.py
+++ b/server/nmtwizard/task.py
@@ -264,7 +264,7 @@ def set_file(redis, taskfile_dir, task_id, content, filename, limit=None):
     taskdir = os.path.join(taskfile_dir, task_id)
     if not os.path.isdir(taskdir):
         os.mkdir(taskdir)
-    with open(os.path.join(taskdir, filename), "w") as fh:
+    with open(os.path.join(taskdir, filename), "w", encoding="utf-8") as fh:
         if limit and len(content) >= limit:
             content = content[:limit-len(disclaimer)] + disclaimer
         content = six.ensure_text(content, encoding="utf-8")


### PR DESCRIPTION
… encoding(ASCII)

('ascii' codec can't encode character '\uff5f' in position 48506: ordinal not in range(128))